### PR TITLE
[netfilter]: Fix skb->csum calculation when netfilter manipulation for NF_NAT_MANIP_SRC\DST is done on IPV6 packet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ https://murgn.com/sadfrogroll
 Made By Murgn#4034
 
 Music Player by Doggo#4340
+
+Absolutely nothing by DankCoder#9983

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Made By Murgn#4034
 
 Music Player by Doggo#4340
 
-Absolutely nothing by DankCoder#9983
+Epic Issues by DankCoder#9983


### PR DESCRIPTION
Fixed a very import security flaw in sadfrogroll that could cause memory leaks in certain testing environments